### PR TITLE
New sort mode Perishable

### DIFF
--- a/Packrat/GuiDialogStorageBrowser.cs
+++ b/Packrat/GuiDialogStorageBrowser.cs
@@ -61,7 +61,7 @@ public class GuiDialogStorageBrowser : GuiDialog
     };
 
     // Sort mode dropdown options
-    private static readonly string[] SortModeNames = { "None", "A-Z", "Category", "Material" };
+    private static readonly string[] SortModeNames = { "None", "A-Z", "Category", "Material", "Perishable" };
 
     public GuiDialogStorageBrowser(
         ICoreClientAPI capi,

--- a/Packrat/SortMode.cs
+++ b/Packrat/SortMode.cs
@@ -23,7 +23,12 @@ public enum SortMode
     /// <summary>
     /// Sort by material type (Stone, Metal, Wood, etc.)
     /// </summary>
-    ByMaterial
+    ByMaterial,
+    
+    /// <summary>
+    /// Sort by hours till item starts perish transition
+    /// </summary>
+    ByPerishable
 }
 
 /// <summary>

--- a/Packrat/SortedInventoryView.cs
+++ b/Packrat/SortedInventoryView.cs
@@ -124,7 +124,7 @@ public class SortedInventoryView : InventoryBase
                 continue;
 
             string sortKey = _sortMode != SortMode.None
-                ? GetSortKey(slot.Itemstack, _sortMode)
+                ? GetSortKey(slot, _sortMode)
                 : i.ToString("D6"); // Preserve original order when not sorting
             int stackSize = slot?.Itemstack?.StackSize ?? 0;
             filteredSlots.Add((i, sortKey, stackSize));
@@ -152,8 +152,9 @@ public class SortedInventoryView : InventoryBase
     /// <summary>
     /// Get the sort key for an item based on the sort mode
     /// </summary>
-    private string GetSortKey(ItemStack stack, SortMode mode)
+    private string GetSortKey(ItemSlot slot, SortMode mode)
     {
+        var stack = slot.Itemstack;
         var collectible = stack.Collectible;
         if (collectible == null) return "zzz"; // Sort unknowns to end
 
@@ -162,8 +163,30 @@ public class SortedInventoryView : InventoryBase
             SortMode.Alphabetical => stack.GetName() ?? collectible.Code?.ToString() ?? "zzz",
             SortMode.ByCategory => $"{(int)GetItemCategory(collectible):D2}_{stack.GetName()}",
             SortMode.ByMaterial => $"{GetMaterialKey(collectible)}_{stack.GetName()}",
+            // Needs padding for the string sort to work with numbers
+            SortMode.ByPerishable => GetRealFreshHoursLeft(slot)?.ToString("0000000000.0000") ?? "zzz",
             _ => "zzz"
         };
+    }
+
+    /// <summary>
+    /// Get the hours left till an item starts to perish in its current container
+    /// </summary>
+    /// <remarks>Ignores temperature as it is irrelevant for sorting</remarks>
+    private float? GetRealFreshHoursLeft(ItemSlot slot)
+    {
+        // Get hours left till spoilage without container multiplier
+        var freshHoursLeft = slot.Itemstack.Collectible.UpdateAndGetTransitionState(_underlying.Api.World, slot, EnumTransitionType.Perish)?.FreshHoursLeft;
+        
+        // Return if not perishable
+        if (freshHoursLeft is null)
+            return null;
+        
+        // Get spoilage multiplier for current container
+        var perishMultiplier = slot.Inventory.GetTransitionSpeedMul(EnumTransitionType.Perish, slot.Itemstack);
+        
+        // Calculate real hours left till spoilage
+        return (float)freshHoursLeft / perishMultiplier;
     }
 
     /// <summary>

--- a/Packrat/SortedInventoryView.cs
+++ b/Packrat/SortedInventoryView.cs
@@ -160,13 +160,21 @@ public class SortedInventoryView : InventoryBase
 
         return mode switch
         {
-            SortMode.Alphabetical => stack.GetName() ?? collectible.Code?.ToString() ?? "zzz",
+            SortMode.Alphabetical => GetAlphabeticalKey(stack),
             SortMode.ByCategory => $"{(int)GetItemCategory(collectible):D2}_{stack.GetName()}",
             SortMode.ByMaterial => $"{GetMaterialKey(collectible)}_{stack.GetName()}",
             // Needs padding for the string sort to work with numbers
-            SortMode.ByPerishable => GetRealFreshHoursLeft(slot)?.ToString("0000000000.0000") ?? "zzz",
+            SortMode.ByPerishable => GetRealFreshHoursLeft(slot)?.ToString("0000000000.0000") ?? GetAlphabeticalKey(stack),
             _ => "zzz"
         };
+    }
+
+    /// <summary>
+    /// Get a sort key for Alphabetical sorting
+    /// </summary>
+    private static string GetAlphabeticalKey(ItemStack stack)
+    {
+        return stack.GetName() ?? stack.Collectible.Code?.ToString() ?? "zzz";
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Adds a new sorting method that orders items from next-to-perish to last-to-perish. Unperishable items are listed at the end in alphabetical order.

## Changes

- Added new sort mode **Perishable** to the dropdown
- Added new sort mode `ByPerishable` to the `SortMode` enum
- Changed the signature of `GetSortKey` to take `ItemSlot` instead of `ItemStack`
    - This is needed to access the transition state
- Moved logic for Alphabetical order into new method `GetAlphabeticalKey`
- Added a new method `GetRealFreshHoursLeft` to determine hours remaining until a perish transition

## Motivation / Context

I wanted an easy way to quickly find items in my cellar that are about to spoil.

## Testing

- Tested in single-player mode
- Multiplayer testing is still pending, but differences are not expected compared to single-player mode

## Breaking Changes

- None

## Additional Notes

I’m not fully sure about the naming in the dropdown and am open to better suggestions.

